### PR TITLE
Add dbName params for choosing database name of MonogoDB.

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -2,6 +2,7 @@ export enum Config {
   PORT = 'PORT',
   MONGO_URI = 'MONGO_URI',
   NODE_ENV = 'NODE_ENV',
+  MONGO_DB_NAME = 'MONGO_DB_NAME',
 }
 
 export const configuration = () => {
@@ -10,5 +11,6 @@ export const configuration = () => {
     [Config.PORT]: +(process.env.PORT ?? DEFAULT_PORT),
     [Config.MONGO_URI]: process.env.MONGO_URI,
     [Config.NODE_ENV]: process.env.NODE_ENV,
+    [Config.MONGO_DB_NAME]: process.env.MONGO_DB_NAME,
   };
 };

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -7,10 +7,11 @@ export enum Config {
 
 export const configuration = () => {
   const DEFAULT_PORT = 3000;
+  const DEFAULT_MONGO_DB = 'meeorder';
   return {
     [Config.PORT]: +(process.env.PORT ?? DEFAULT_PORT),
     [Config.MONGO_URI]: process.env.MONGO_URI,
     [Config.NODE_ENV]: process.env.NODE_ENV,
-    [Config.MONGO_DB_NAME]: process.env.MONGO_DB_NAME,
+    [Config.MONGO_DB_NAME]: process.env.MONGO_DB_NAME ?? DEFAULT_MONGO_DB,
   };
 };

--- a/src/config/typegoose.config.service.ts
+++ b/src/config/typegoose.config.service.ts
@@ -13,6 +13,7 @@ export class TypegooseConfigService implements TypegooseOptionsFactory {
   createTypegooseOptions(): TypegooseModuleOptions {
     return {
       uri: this.configService.get<string>(Config.MONGO_URI),
+      dbName: this.configService.get<string>(Config.MONGO_DB_NAME),
     };
   }
 }


### PR DESCRIPTION
When I use `MONGO_URI=mongodb://root:example@localhost:27017/meeorder` to specify the database name `meeorder` it won't work (Cannot connect to the database when start the app.
So I have to add the `dbName` param inside typegoose configuration.