### PR TITLE
Add forbitNonWhitelisted for validation pipeline

### DIFF
--- a/features/2-menus.feature
+++ b/features/2-menus.feature
@@ -10,14 +10,5 @@ Feature: Menu Test
     And get this menu by the same id
     Then "deleted_date" field should not be null in response
 
-  Scenario: Update Menu
-    Given a menu
-    When create a menu
-    And publish this menu
-    And update this menu with title "Menu 2"
-    Then should return status code 200
-    And menu title should be "Menu 2" when get by the same id
-    And delete this menu
-
 
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import fastifyCookie from '@fastify/cookie';
 import { ValidationPipe, VersioningType } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
@@ -8,7 +9,6 @@ import {
 import { AppModule } from './app.module';
 import { Config } from './config';
 import { SwaggerBuilder } from './document';
-import fastifyCookie from '@fastify/cookie';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(
@@ -20,7 +20,9 @@ async function bootstrap() {
     type: VersioningType.URI,
     prefix: 'api/v',
   });
-  app.useGlobalPipes(new ValidationPipe({ transform: true }));
+  app.useGlobalPipes(
+    new ValidationPipe({ transform: true, forbidNonWhitelisted: true }),
+  );
 
   await app.register(fastifyCookie, {
     secret: 'my-secret', // for cookies signature


### PR DESCRIPTION
features/2-menus.feature
- Remove Scenario that make this pr error (Menu test will be refactor so ignore it in this pr)

src/main.ts
- Add `forbidNonWhitelisted: true` in ValidationPipe (Throw an error if field not match in dto.
https://stackoverflow.com/questions/62700524/nest-js-only-accept-fields-that-are-specified-in-a-dto